### PR TITLE
修复无限重启的minicap，并根据启动时决定横竖屏状态

### DIFF
--- a/minidevice/device.py
+++ b/minidevice/device.py
@@ -143,3 +143,25 @@ class MiniDevice:
                     threading.Thread(target=waitFunc).start()  # 启动一个新线程在上一个操作执行完后执行当前操作
             finally:
                 self.__touchThreadLock.release()
+
+    def width(self):
+        """
+        设备的width
+        :return:
+        """
+        w = -1
+        if isinstance(self.__touchMethod, MaaTouch):
+            tempTouchMethod: MaaTouch = self.__touchMethod
+            w = int(tempTouchMethod.max_x)
+        return w
+
+    def height(self):
+        """
+        设备的height
+        :return:
+        """
+        h = -1
+        if isinstance(self.__touchMethod, MaaTouch):
+            tempTouchMethod: MaaTouch = self.__touchMethod
+            h = int(tempTouchMethod.max_y)
+        return h

--- a/minidevice/device.py
+++ b/minidevice/device.py
@@ -6,7 +6,7 @@ from minidevice.logger import logger
 
 class MiniDevice:
     def __init__(self, serial=None, capMethod: Union[ADBCap, MiniCap, DroidCast] = None,
-                 touchMethod: Union[ADBTouch, MiniTouch, MaaTouch] = None, screenshotTimeout=500) -> None:
+                 touchMethod: Union[ADBTouch, MiniTouch, MaaTouch] = None, screenshotTimeout=15) -> None:
         """设备操作类
 
         Args:

--- a/minidevice/minicap.py
+++ b/minidevice/minicap.py
@@ -220,9 +220,9 @@ class MiniCap(ScreenCap):
 
     def screencap_raw(self) -> bytes:
         if self.__use_stream:
-            if self.__minicap_popen.poll() is not None:
-                self.__stop_minicap_by_stream()
-                self.__start_minicap_by_stream()
+            #if self.__minicap_popen.poll() is not None:
+                #self.__stop_minicap_by_stream()
+                #self.__start_minicap_by_stream()
             return self.__screen_queue.get()
         else:
             return self.__minicap_frame()

--- a/minidevice/minicap.py
+++ b/minidevice/minicap.py
@@ -5,7 +5,7 @@ import subprocess
 import threading
 import time
 
-from adbutils import adb,adb_path
+from adbutils import adb, adb_path
 from minidevice.QueueUtils import PipeQueue
 from minidevice.screencap import ScreenCap
 
@@ -36,25 +36,25 @@ class Banner:
 
     def __str__(self):
         message = (
-            "Banner [Version="
-            + str(self.Version)
-            + ", length="
-            + str(self.Length)
-            + ", Pid="
-            + str(self.Pid)
-            + ", realWidth="
-            + str(self.RealWidth)
-            + ", realHeight="
-            + str(self.RealHeight)
-            + ", virtualWidth="
-            + str(self.VirtualWidth)
-            + ", virtualHeight="
-            + str(self.VirtualHeight)
-            + ", orientation="
-            + str(self.Orientation)
-            + ", quirks="
-            + str(self.Quirks)
-            + "]"
+                "Banner [Version="
+                + str(self.Version)
+                + ", length="
+                + str(self.Length)
+                + ", Pid="
+                + str(self.Pid)
+                + ", realWidth="
+                + str(self.RealWidth)
+                + ", realHeight="
+                + str(self.RealHeight)
+                + ", virtualWidth="
+                + str(self.VirtualWidth)
+                + ", virtualHeight="
+                + str(self.VirtualHeight)
+                + ", orientation="
+                + str(self.Orientation)
+                + ", quirks="
+                + str(self.Quirks)
+                + "]"
         )
         return message
 
@@ -135,24 +135,24 @@ class MinicapStream:
                         self.banner.Length = bannerLength
                     elif readBannerBytes in [2, 3, 4, 5]:
                         self.banner.Pid += (
-                            chunk[cursor] << ((readBannerBytes - 2) * 8)
-                        ) >> 0
+                                                   chunk[cursor] << ((readBannerBytes - 2) * 8)
+                                           ) >> 0
                     elif readBannerBytes in [6, 7, 8, 9]:
                         self.banner.RealWidth += (
-                            chunk[cursor] << ((readBannerBytes - 6) * 8)
-                        ) >> 0
+                                                         chunk[cursor] << ((readBannerBytes - 6) * 8)
+                                                 ) >> 0
                     elif readBannerBytes in [10, 11, 12, 13]:
                         self.banner.RealHeight += (
-                            chunk[cursor] << ((readBannerBytes - 10) * 8)
-                        ) >> 0
+                                                          chunk[cursor] << ((readBannerBytes - 10) * 8)
+                                                  ) >> 0
                     elif readBannerBytes in [14, 15, 16, 17]:
                         self.banner.VirtualWidth += (
-                            chunk[cursor] << ((readBannerBytes - 14) * 8)
-                        ) >> 0
+                                                            chunk[cursor] << ((readBannerBytes - 14) * 8)
+                                                    ) >> 0
                     elif readBannerBytes in [18, 19, 20, 21]:
                         self.banner.VirtualHeight += (
-                            chunk[cursor] << ((readBannerBytes - 18) * 8)
-                        ) >> 0
+                                                             chunk[cursor] << ((readBannerBytes - 18) * 8)
+                                                     ) >> 0
                     elif readBannerBytes == 22:
                         self.banner.Orientation = chunk[cursor] * 90
                     elif readBannerBytes == 23:
@@ -164,14 +164,14 @@ class MinicapStream:
                 # 读取图片大小数据
                 elif readFrameBytes < 4:
                     frameBodyLength = frameBodyLength + (
-                        (chunk[cursor] << (readFrameBytes * 8)) >> 0
+                            (chunk[cursor] << (readFrameBytes * 8)) >> 0
                     )
                     cursor += 1
                     readFrameBytes += 1
                 # 读取图片内容
                 else:
                     if length - cursor >= frameBodyLength:
-                        dataBody = dataBody + chunk[cursor : (cursor + frameBodyLength)]
+                        dataBody = dataBody + chunk[cursor: (cursor + frameBodyLength)]
                         if dataBody[0] != 0xFF or dataBody[1] != 0xD8:
                             return
                         self.queue.put(dataBody)
@@ -195,11 +195,11 @@ class MinicapStream:
 
 class MiniCap(ScreenCap):
     def __init__(
-        self,
-        serial,
-        rate=15,
-        quality=100,
-        use_stream=True,
+            self,
+            serial,
+            rate=15,
+            quality=100,
+            use_stream=True,
     ) -> None:
         """
         __init__ minicap截图方式
@@ -211,6 +211,13 @@ class MiniCap(ScreenCap):
             use_stream (bool, optional): 是否使用stream的方式. Defaults to True.
         """
         self.__adb = adb.device(serial)
+
+        # 先重置 minicap
+        # Kill the existing Minicap process
+        self.__adb.shell(['pkill', '-9', 'minicap'])
+        # Restart Minicap service
+        self.__adb.shell(['am', 'startservice', '-n', 'com.example.minicap/.MinicapService'])
+
         self.__use_stream = use_stream
         self.__quality = quality
         self.__rate = rate
@@ -220,9 +227,9 @@ class MiniCap(ScreenCap):
 
     def screencap_raw(self) -> bytes:
         if self.__use_stream:
-            #if self.__minicap_popen.poll() is not None:
-                #self.__stop_minicap_by_stream()
-                #self.__start_minicap_by_stream()
+            # if self.__minicap_popen.poll() is not None:
+            # self.__stop_minicap_by_stream()
+            # self.__start_minicap_by_stream()
             return self.__screen_queue.get()
         else:
             return self.__minicap_frame()
@@ -241,8 +248,33 @@ class MiniCap(ScreenCap):
         jpg_data = jpg_data.replace(line_breaker(self.__sdk), b"\n")
         return jpg_data
 
+    def get_screen_orientation(self):
+        """
+        Get the screen orientation of the device.
+        :return: 'portrait' if the screen orientation is portrait, 'landscape' if it's landscape.
+        """
+        # Execute adb shell command to get the screen orientation
+        output = self.__adb.shell(['dumpsys', 'input', '|\grep', 'SurfaceOrientation'])
+
+        # Extract the orientation from the output
+        orientation = 'portrait' if 'SurfaceOrientation: 0' in output else 'landscape'
+
+        return orientation
+
     def __get_device_info(self):
-        self.__vm_size = self.__adb.shell("wm size").split(" ")[-1]
+        # 根据此时的状态决定是横屏竖屏
+        if self.get_screen_orientation() == 'landscape':
+            # 获得原始设备尺寸
+            rawMessage = self.__adb.shell("wm size").split(" ")[-1].split("x")
+            # 大的尺寸
+            bigSize = max(int(rawMessage[0]), int(rawMessage[1]))
+            # 小的尺寸
+            smallSize = min(int(rawMessage[0]), int(rawMessage[1]))
+            # 目标尺寸
+            purposeSize = f"{bigSize}x{smallSize}"
+        else:
+            purposeSize = self.__adb.shell("wm size").split(" ")[-1]
+        self.__vm_size = purposeSize
         self.__abi = self.__adb.getprop("ro.product.cpu.abi")
         self.__sdk = self.__adb.getprop("ro.build.version.sdk")
 
@@ -320,5 +352,3 @@ class MiniCap(ScreenCap):
 
     def __del__(self):
         self.__stop_minicap_by_stream()
-
-

--- a/minidevice/minicap.py
+++ b/minidevice/minicap.py
@@ -227,9 +227,9 @@ class MiniCap(ScreenCap):
 
     def screencap_raw(self) -> bytes:
         if self.__use_stream:
-            # if self.__minicap_popen.poll() is not None:
-            # self.__stop_minicap_by_stream()
-            # self.__start_minicap_by_stream()
+            if self.__minicap_popen.poll() is not None:
+                self.__stop_minicap_by_stream()
+                self.__start_minicap_by_stream()
             return self.__screen_queue.get()
         else:
             return self.__minicap_frame()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 adbutils
+loguru


### PR DESCRIPTION
feat: 屏蔽掉无限重启的 minicap
feat: 流传输图的截图时间间隔设置为15ms
feat: minicap每次启动时，先用adb结束以前的进程。每次启动程序，根据当前手机的横竖屏状态决定此次运行的图像横竖屏状态